### PR TITLE
Update 01-databases.sql

### DIFF
--- a/mysql-few-databases/docker/provision/mysql/init/01-databases.sql
+++ b/mysql-few-databases/docker/provision/mysql/init/01-databases.sql
@@ -1,7 +1,7 @@
-# create databases
+-- create databases
 CREATE DATABASE IF NOT EXISTS `primary`;
 CREATE DATABASE IF NOT EXISTS `secondary`;
 
-# create root user and grant rights
+-- create root user and grant rights
 CREATE USER 'root'@'localhost' IDENTIFIED BY 'local';
-GRANT ALL ON *.* TO 'root'@'%';
+GRANT ALL ON *.* TO 'root'@'localhost';


### PR DESCRIPTION
Two proposed changes here:

1. Update the comment marker from `#` to `--` (SQL standard).
2. From mysql 8 on we can't `create a user with the grant command`. If you create the user with `'<username>'@'localhost'` and then try to `GRANT .... TO "<username>"@"%" ...`, since the "host" is differente (`localhost` x `%`) it will try to "create a new user", thus it will fail to start.